### PR TITLE
Add docker compose support to ease up setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+adb.php
+libraries/*
+!libraries/placeholder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  php-cli:
+    image: php:8.2-apache
+    restart: unless-stopped
+    volumes:
+      - .:/var/www/html

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+####
+# Setup environment to run application in a docker container
+#
+# @todo:
+#   
+#
+# @author: stev leibelt <artodeto@bazzline.net>
+# @since: 2024-01-31
+####
+
+function _build ()
+{
+  # stop execution if one comand fails
+  set -e
+
+  local PATH_OF_THIS_SCRIPT
+
+  PATH_OF_THIS_SCRIPT=$(realpath "$(dirname "${0}")")
+
+  if [[ ! -f "${PATH_OF_THIS_SCRIPT}"/adb.php ]];
+  then
+    wget -O "${PATH_OF_THIS_SCRIPT}"/adb.php https://raw.githubusercontent.com/MlgmXyysd/php-adb/master/src/adb.php
+  fi
+
+  if [[ ! -f "${PATH_OF_THIS_SCRIPT}"/libraries/adb ]];
+  then
+    wget -O "${PATH_OF_THIS_SCRIPT}"/libraries/tools.zip https://dl.google.com/android/repository/platform-tools_r34.0.5-linux.zip
+    unzip -d "${PATH_OF_THIS_SCRIPT}"/libraries "${PATH_OF_THIS_SCRIPT}"/libraries/tools.zip
+    rm "${PATH_OF_THIS_SCRIPT}"/libraries/tools.zip
+    mv "${PATH_OF_THIS_SCRIPT}"/libraries/platform-tools/* "${PATH_OF_THIS_SCRIPT}"/libraries/
+    rmdir "${PATH_OF_THIS_SCRIPT}"/libraries/platform-tools
+  fi
+}
+
+function _main ()
+{
+  case "${1}" in
+    bulid)
+      _build
+      ;;
+    login)
+      _login
+      ;;
+    start)
+      _start
+      ;;
+    stop)
+      _stop
+      ;;
+    *)
+      echo "Usage: ${0} {build|login|start|stop}"
+      return 1
+      ;;
+  esac
+}
+
+function _login ()
+{
+  _start
+  docker compose exec php-cli bash
+}
+
+function _start ()
+{
+  _stop
+  _build
+  docker compose up -d
+}
+
+function _stop ()
+{
+  docker compose down
+}
+
+_main "${@}"


### PR DESCRIPTION
I've added three things:

* .gitignore file
* run.sh bash script to simple setup this project
* docker-compose.yml to use docker to simplify project usage

What I can not do is to update the README.

Either replace the setup procedure or move it under a headline like "Manually setup".

The bash script is working on my machine (arch linux). Mandatory are the commands `wget`, `unzip`, `docker-compose`.
In my idea world, all a user needs to do is to:
* git clone ...
* bash run.sh login
* do his things
* basn run.sh stop

Kind regards and thanks for your work.