### PR TITLE
Fix issue that adb can not find any attached device

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   php-cli:
     image: php:8.2-apache
+    privileged: true
     restart: unless-stopped
     volumes:
       - .:/var/www/html
+      - /dev/bus/usb:/dev/bus/usb

--- a/run.sh
+++ b/run.sh
@@ -65,6 +65,10 @@ function _start ()
 {
   _stop
   _build
+  if command -v adb &> /dev/null;
+  then
+    adb kill-server
+  fi
   docker compose up -d
 }
 


### PR DESCRIPTION
With this fix, we are able to see the attached device with adb.

That is all I can test so far.

![image](https://github.com/MlgmXyysd/Xiaomi-HyperOS-BootLoader-Bypass/assets/2287220/8fc4895e-d0b1-4ee9-9945-ec5e9ee8ca6f)
