### PR TITLE
Fixed error in run.sh and added check if rom_version exists in $data

### DIFF
--- a/bypass.php
+++ b/bypass.php
@@ -230,6 +230,12 @@ function decryptData(string $data): string|false
 	return openssl_decrypt(base64_decode($data), "AES-128-CBC", $GLOBALS["data_pass"], OPENSSL_RAW_DATA, $GLOBALS["data_iv"]);
 }
 
+function outputErrormessageAndExit(string $message)
+{
+  printf("Error:: %s.", $message);
+  exit(10)
+}
+
 /***********************
  *    Functions End    *
  ***********************/
@@ -328,6 +334,11 @@ if (is_resource($process)) {
 logf("Refactoring parameters...");
 
 $data = json_decode(decryptData($args), true);
+
+if (!array_key_exists("rom_version", $data)) {
+  $dataAsJSON = json_encode($data)
+  outputErrormessageAndExit("Invalid data, key 'rom_version' not found: " . $dataAsJSON)
+}
 
 // V816 is the special identity for HyperOS in MIUI version
 $data["rom_version"] = str_replace("V816", "V14", $data["rom_version"]);

--- a/bypass.php
+++ b/bypass.php
@@ -233,7 +233,7 @@ function decryptData(string $data): string|false
 function outputErrormessageAndExit(string $message)
 {
   printf("Error:: %s.", $message);
-  exit(10)
+  exit(10);
 }
 
 /***********************
@@ -336,8 +336,8 @@ logf("Refactoring parameters...");
 $data = json_decode(decryptData($args), true);
 
 if (!array_key_exists("rom_version", $data)) {
-  $dataAsJSON = json_encode($data)
-  outputErrormessageAndExit("Invalid data, key 'rom_version' not found: " . $dataAsJSON)
+  $dataAsJSON = json_encode($data);
+  outputErrormessageAndExit("Invalid data, key 'rom_version' not found: " . $dataAsJSON);
 }
 
 // V816 is the special identity for HyperOS in MIUI version

--- a/bypass.php
+++ b/bypass.php
@@ -335,6 +335,10 @@ logf("Refactoring parameters...");
 
 $data = json_decode(decryptData($args), true);
 
+if (!is_array($data)) {
+  $argsAsJSON = json_encode($args);
+  outputErrormessageAndExit("Data is not an array. Unencryptes args as json are:" . $argsAsJSON);
+}
 if (!array_key_exists("rom_version", $data)) {
   $dataAsJSON = json_encode($data);
   outputErrormessageAndExit("Invalid data, key 'rom_version' not found: " . $dataAsJSON);

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ function _build ()
 function _main ()
 {
   case "${1}" in
-    bulid)
+    build)
       _build
       ;;
     login)


### PR DESCRIPTION
This is the result of fixing the error reported in [issues/201](https://github.com/MlgmXyysd/Xiaomi-HyperOS-BootLoader-Bypass/issues/201).

As bonus, I found and fixed an error in `run.sh`. `build` was never working.