### PR TITLE
fix: 纠正run.sh中的拼写错误`bulid`为`build`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ function _build ()
 function _main ()
 {
   case "${1}" in
-    bulid)
+    build)
       _build
       ;;
     login)


### PR DESCRIPTION
# 摘要
- 修改`run.sh`中的`bulid)`为`build)`